### PR TITLE
Issue 1044 and 1045

### DIFF
--- a/scripts/app
+++ b/scripts/app
@@ -208,7 +208,7 @@ fi
 # Starts an installed app
 if [[ "$command" = "start" ]]; then
 
-  if ! list_installed_apps | grep --quiet "^${app}$"; then
+  if ! list_installed_apps | grep -q "^${app}$"; then
     echo "Error: app \"${app}\" is not installed yet"
     exit 1
   fi

--- a/scripts/umbrel-os/external-storage/monitor
+++ b/scripts/umbrel-os/external-storage/monitor
@@ -24,17 +24,17 @@ main () {
       break
     fi
 
-    if ! grep --quiet " ${mount_point} " /proc/mounts; then
+    if ! grep -q " ${mount_point} " /proc/mounts; then
       echo "External storage is no longer mounted!"
       break
     fi
 
-    if grep " ${mount_point} " /proc/mounts | grep --quiet '[ ,]ro[ ,]'; then
+    if grep " ${mount_point} " /proc/mounts | grep -q '[ ,]ro[ ,]'; then
       echo "External storage is mounted as read only!"
       break
     fi
 
-    if ! df -h "${UMBREL_ROOT}" | grep --quiet "/dev/${block_device}"; then
+    if ! df -h "${UMBREL_ROOT}" | grep -q "/dev/${block_device}"; then
       echo "Umbrel root is no longer bind mounted to external storage!"
       break
     fi

--- a/scripts/umbrel-os/external-storage/mount
+++ b/scripts/umbrel-os/external-storage/mount
@@ -87,7 +87,7 @@ is_partition_ext4 () {
   # We need to run sync here to make sure the filesystem is reflecting the
   # the latest changes in /dev/*
   sync
-  blkid -o value -s TYPE "${partition_path}" | grep --quiet '^ext4$'
+  blkid -o value -s TYPE "${partition_path}" | grep -q '^ext4$'
 }
 
 # Wipes a block device and reformats it with a single EXT4 partition
@@ -129,19 +129,13 @@ setup_new_device () {
 
   echo "Copying Umbrel install to external storage..."
   mkdir -p "${EXTERNAL_UMBREL_ROOT}"
-  cp  --recursive \
-      --archive \
-      --no-target-directory \
-      "${UMBREL_ROOT}" "${EXTERNAL_UMBREL_ROOT}"
+  cp  -raT "${UMBREL_ROOT}" "${EXTERNAL_UMBREL_ROOT}"
 }
 
 # Copy Docker data dir to external storage
 copy_docker_to_external_storage () {
   mkdir -p "${EXTERNAL_DOCKER_DIR}"
-  cp  --recursive \
-      --archive \
-      --no-target-directory \
-      "${DOCKER_DIR}" "${EXTERNAL_DOCKER_DIR}"
+  cp  -raT "${DOCKER_DIR}" "${EXTERNAL_DOCKER_DIR}"
 }
 
 main () {
@@ -249,13 +243,13 @@ main () {
   echo "Checking Umbrel root is now on external storage..."
   sync
   sleep 1
-  df -h "${UMBREL_ROOT}" | grep --quiet '/dev/sd'
+  df -h "${UMBREL_ROOT}" | grep -q '/dev/sd'
 
   echo "Checking ${DOCKER_DIR} is now on external storage..."
-  df -h "${DOCKER_DIR}" | grep --quiet '/dev/sd'
+  df -h "${DOCKER_DIR}" | grep -q '/dev/sd'
 
   echo "Checking ${SWAP_DIR} is now on external storage..."
-  df -h "${SWAP_DIR}" | grep --quiet '/dev/sd'
+  df -h "${SWAP_DIR}" | grep -q '/dev/sd'
 
   echo "Setting up swapfile"
   rm "${SWAP_FILE}" || true
@@ -265,7 +259,7 @@ main () {
   swapon "${SWAP_FILE}"
 
   echo "Checking SD Card root is bind mounted at /sd-root..."
-  df -h "/sd-root${UMBREL_ROOT}" | grep --quiet "/dev/root"
+  df -h "/sd-root${UMBREL_ROOT}" | grep -q "/dev/root"
 
   echo "Starting external drive mount monitor..."
   echo

--- a/scripts/umbrel-os/external-storage/update-from-sdcard
+++ b/scripts/umbrel-os/external-storage/update-from-sdcard
@@ -27,7 +27,7 @@ check_dependencies () {
 check_semver_range () {
   local range="${1}"
   local version="${2}"
-  "${UMBREL_ROOT}/scripts/umbrel-os/semver" -r "${range}" "${version}" | grep --quiet "^${version}$"
+  "${UMBREL_ROOT}/scripts/umbrel-os/semver" -r "${range}" "${version}" | grep -q "^${version}$"
 }
 
 main () {

--- a/scripts/umbrel-os/service-monitor
+++ b/scripts/umbrel-os/service-monitor
@@ -25,11 +25,11 @@ has_service_failed () {
 }
 
 has_umbrel_started () {
-  cat "${STATUS_FILE_PATH}" | grep --silent '^umbrel:completed$'
+  cat "${STATUS_FILE_PATH}" | grep -q '^umbrel:completed$'
 }
 
 has_error_been_caught () {
-  cat "${STATUS_FILE_PATH}" | grep --silent ':errored:'
+  cat "${STATUS_FILE_PATH}" | grep -q ':errored:'
 }
 
 check_root

--- a/scripts/update/01-run.sh
+++ b/scripts/update/01-run.sh
@@ -64,7 +64,7 @@ if [[ ! -z "${UMBREL_OS:-}" ]]; then
     # Make sure dhcpd ignores virtual network interfaces
     dhcpd_conf="/etc/dhcpcd.conf"
     dhcpd_rule="denyinterfaces veth*"
-    if [[ -f "${dhcpd_conf}" ]] && ! cat "${dhcpd_conf}" | grep --quiet "${dhcpd_rule}"; then
+    if [[ -f "${dhcpd_conf}" ]] && ! cat "${dhcpd_conf}" | grep -q "${dhcpd_rule}"; then
       echo "${dhcpd_rule}" | tee -a "${dhcpd_conf}"
       systemctl restart dhcpcd
     fi
@@ -165,10 +165,7 @@ EOF
   # Copy Docker data dir to external storage
   copy_docker_to_external_storage () {
     mkdir -p "${EXTERNAL_DOCKER_DIR}"
-    cp  --recursive \
-        --archive \
-        --no-target-directory \
-        "${DOCKER_DIR}" "${EXTERNAL_DOCKER_DIR}"
+    cp  -raT "${DOCKER_DIR}" "${EXTERNAL_DOCKER_DIR}"
   }
 
   echo "Copying Docker data directory to external storage..."
@@ -199,7 +196,7 @@ rsync --archive \
 legacy_electrs_dir="${UMBREL_ROOT}/electrs/db/mainnet"
 if [[ -d "${legacy_electrs_dir}" ]]; then
   echo "Found legacy electrs dir, removing it..."
-  rm --recursive --force "${legacy_electrs_dir}"
+  rm -rf "${legacy_electrs_dir}"
 fi
 
 # Handle updating static assets for samourai-server app
@@ -268,7 +265,7 @@ EOF
   MOUNT_POINT="/mnt/data"
   SWAP_DIR="/swap"
   SWAP_FILE="${SWAP_DIR}/swapfile"
-  if ! df -h "${SWAP_DIR}" 2> /dev/null | grep --quiet '/dev/sd'; then
+  if ! df -h "${SWAP_DIR}" 2> /dev/null | grep -q '/dev/sd'; then
     cat <<EOF > "$UMBREL_ROOT"/statuses/update-status.json
 {"state": "installing", "progress": 97, "description": "Setting up swap", "updateTo": "$RELEASE"}
 EOF
@@ -278,7 +275,7 @@ EOF
     mount --bind "${MOUNT_POINT}/swap" "${SWAP_DIR}"
 
     echo "Checking ${SWAP_DIR} is now on external storage..."
-    df -h "${SWAP_DIR}" | grep --quiet '/dev/sd'
+    df -h "${SWAP_DIR}" | grep -q '/dev/sd'
 
     echo "Setting up swapfile"
     rm "${SWAP_FILE}" || true

--- a/scripts/update/update
+++ b/scripts/update/update
@@ -106,10 +106,7 @@ fi
 if [[ "${update_type}" == "path" ]]; then
   echo "Copying Umbrel ${RELEASE} from ${update_path}"
   mkdir -p "${UMBREL_ROOT}/.umbrel-${RELEASE}"
-  cp --recursive \
-    --archive \
-    --no-target-directory \
-    "${update_path}" "${UMBREL_ROOT}/.umbrel-${RELEASE}"
+  cp -raT "${update_path}" "${UMBREL_ROOT}/.umbrel-${RELEASE}"
   cd "${UMBREL_ROOT}/.umbrel-${RELEASE}"
 fi
 


### PR DESCRIPTION
Replaced "grep --quiet" and "grep --silent" with "grep -q" to be more universal across Linux distros.
Replaced "rm --recursive --force" with "rm -rf" for the same reason as above.

Replaced "cp --recursive --archive --no-target-directory ..." with " cp -raT ...", again for broader compatibility.

I do realize this trades off better readibility of code for less readable, but more widely compatible one. Ideally, we can be able to install and run Umbrel code base on smaller and more secure Linux distros and not just Ubuntu and Debian ones.